### PR TITLE
Ajustado import da validação da inscrição estadual

### DIFF
--- a/l10n_br_crm/crm_lead.py
+++ b/l10n_br_crm/crm_lead.py
@@ -60,7 +60,7 @@ class CrmLead(models.Model):
     def _validate_ie_param(self, uf, inscr_est):
         try:
             mod = __import__(
-                'tools.fiscal', globals(), locals(), 'fiscal')
+                'openerp.addons.l10n_br_base.tools.fiscal', globals(), locals(), 'fiscal')
 
             validate = getattr(mod, 'validate_ie_%s' % uf)
             if not validate(inscr_est):


### PR DESCRIPTION
Ajustada cláusula import da validação da inscrição estadual.

Estava acusando o seguinte erro:
ValidationError: ('ValidateError', u'Error while validating constraint\n\nNo module named tools.fiscal')

Troquei para o import completo "openerp.addons.l10n_br_base.tools.fiscal"