### PR TITLE
Retirado teste "not self.is_company" da IE

### DIFF
--- a/l10n_br_crm/crm_lead.py
+++ b/l10n_br_crm/crm_lead.py
@@ -78,8 +78,7 @@ class CrmLead(models.Model):
 
         :Return: True or False."""
         if (not self.inscr_est
-                or self.inscr_est == 'ISENTO'
-                or not self.is_company):
+                or self.inscr_est == 'ISENTO'):
             return True
         uf = (self.state_id and
               self.state_id.code.lower() or '')


### PR DESCRIPTION
Retirado teste "not self.is_company" da validação da Inscrição Estadual, pois o modelo crm.lead não possui este campo.

Caso haja uma solução melhor me informem que procuro implementar.

Obrigado!