### PR TITLE
Feature/adicionar transportadora

### DIFF
--- a/l10n_br_account_product/account_invoice.py
+++ b/l10n_br_account_product/account_invoice.py
@@ -179,16 +179,20 @@ class AccountInvoice(models.Model):
                    ('2', u'Terceiros'),
                    ('9', u'Sem Frete')],
         string=u'Frete por Conta',
-        required=True, default='9')       
+        required=True, default='9', readonly=True,
+        states={'draft': [('readonly', False)]})
     partner_carrier_id = fields.Many2one(
         'res.partner', u'Transportadora', readonly=True,
         states={'draft': [('readonly', False)]},
         domain=[('is_carrier', '=', True)])
-    vehicle_plate = fields.Char('Placa do Veiculo', size=7)
+    vehicle_plate = fields.Char('Placa do Veiculo', size=7, readonly=True,
+                                states={'draft': [('readonly', False)]})
     vehicle_state_id = fields.Many2one(
-        'res.country.state', 'UF da Placa')
+        'res.country.state', 'UF da Placa', readonly=True,
+        states={'draft': [('readonly', False)]})
     vehicle_l10n_br_city_id = fields.Many2one('l10n_br_base.city',
-        'Municipio', domain="[('state_id', '=', vehicle_state_id)]")
+        'Municipio', domain="[('state_id', '=', vehicle_state_id)]",
+        readonly=True, states={'draft': [('readonly', False)]})
     amount_gross = fields.Float(
         string='Vlr. Bruto', digits=dp.get_precision('Account'),  store=True,
         readonly=True, compute='_compute_amount')

--- a/l10n_br_account_product/account_invoice.py
+++ b/l10n_br_account_product/account_invoice.py
@@ -173,7 +173,17 @@ class AccountInvoice(models.Model):
         'l10n_br_account_product.document.related', 'invoice_id',
         'Fiscal Document Related', readonly=True,
         states={'draft': [('readonly', False)]})
-    carrier_name = fields.Char('Nome Transportadora', size=32)
+    freight_responsibility = fields.Selection(
+        selection=[('0', u'Emitente'),
+                   ('1', u'Destinatário'),
+                   ('2', u'Terceiros'),
+                   ('9', u'Sem Frete')],
+        string=u'Frete por Conta',
+        required=True, default='9')       
+    partner_carrier_id = fields.Many2one(
+        'res.partner', u'Transportadora', readonly=True,
+        states={'draft': [('readonly', False)]},
+        domain=[('is_carrier', '=', True)])
     vehicle_plate = fields.Char('Placa do Veiculo', size=7)
     vehicle_state_id = fields.Many2one(
         'res.country.state', 'UF da Placa')

--- a/l10n_br_account_product/account_invoice_view.xml
+++ b/l10n_br_account_product/account_invoice_view.xml
@@ -72,15 +72,21 @@
 								</group>
 							</page>
 							<page string="Transporte">
-								<group name="delivery_info">
-									<field name="carrier_name"/>
-									<field name="vehicle_plate"/>
-									<field name="vehicle_state_id"/>
-									<field name="vehicle_l10n_br_city_id"/>
-									<field name="amount_freight"/>
-									<field name="amount_insurance"/>
-									<field name="amount_costs"/>
-                                    <button string="Recalcular Custos" states="draft" name="%(action_l10n_br_account_product_costs_ratio)d" type="action"/>
+								<group name="transport" col="4">
+									<group name="delivery_info">
+										<field name="freight_responsibility" />
+										<field name="partner_carrier_id" context="{'default_customer': False, 'default_supplier': True,
+																					'default_is_carrier': True, 'default_is_company':True }" />
+										<field name="vehicle_plate"/>
+										<field name="vehicle_state_id"/>
+										<field name="vehicle_l10n_br_city_id"/>
+									</group>
+									<group name="freight_values">
+										<field name="amount_freight"/>
+										<field name="amount_insurance"/>
+										<field name="amount_costs"/>
+	                                    <button string="Recalcular Custos" states="draft" name="%(action_l10n_br_account_product_costs_ratio)d" type="action"/>
+									</group>
 								</group>
 								<group name="package_info" string="Informações dos pacotes">
 									<field name="weight"/>
@@ -215,15 +221,21 @@
 								</group>
 							</page>
 							<page string="Transporte">
-								<group name="delivery_info">
-									<field name="carrier_name"/>
-									<field name="vehicle_plate"/>
-									<field name="vehicle_state_id"/>
-									<field name="vehicle_l10n_br_city_id"/>
-									<field name="amount_freight"/>
-									<field name="amount_insurance"/>
-									<field name="amount_costs"/>
-                                    <button string="Recalcular Custos" states="draft" name="%(action_l10n_br_account_product_costs_ratio)d" type="action"/>
+								<group name="transport" col="4">
+									<group name="delivery_info">
+										<field name="freight_responsibility" />
+										<field name="partner_carrier_id" context="{'default_customer': False, 'default_supplier': True,
+																					'default_is_carrier': True, 'default_is_company':True }" />
+										<field name="vehicle_plate"/>
+										<field name="vehicle_state_id"/>
+										<field name="vehicle_l10n_br_city_id"/>
+									</group>
+									<group name="freight_values">
+										<field name="amount_freight"/>
+										<field name="amount_insurance"/>
+										<field name="amount_costs"/>
+	                                    <button string="Recalcular Custos" states="draft" name="%(action_l10n_br_account_product_costs_ratio)d" type="action"/>
+									</group>
 								</group>
 								<group name="package_info" string="Informações dos pacotes">
 									<field name="weight"/>

--- a/l10n_br_account_product/res_partner.py
+++ b/l10n_br_account_product/res_partner.py
@@ -17,12 +17,20 @@
 #along with this program.  If not, see <http://www.gnu.org/licenses/>.        #
 ###############################################################################
 
+
 from openerp.osv import orm, fields
 
 FISCAL_POSITION_COLUMNS = {
     'cfop_id': fields.many2one('l10n_br_account_product.cfop', 'CFOP'),
 }
 
+class ResPartner(orm.Model):
+    _inherit = 'res.partner'
+    
+    _columns = {
+        'is_carrier': fields.boolean("Transportadora?", 
+                                     help="O parceiro é uma transportadora?")
+    }
 
 class AccountFiscalPositionTemplate(orm.Model):
     _inherit = 'account.fiscal.position.template'

--- a/l10n_br_account_product/res_partner_view.xml
+++ b/l10n_br_account_product/res_partner_view.xml
@@ -26,5 +26,17 @@
 			</field>
 		</record>
 
+		
+		<record id="l10n_br_account_product_view_partner_form" model="ir.ui.view">
+			<field name="name">l10n_br_account_product.partner.form</field>
+			<field name="model">res.partner</field>
+			<field name="inherit_id" ref="base.view_partner_form"/>
+			<field name="arch" type="xml">
+				<field name="user_id" position="after">
+					<field name="is_carrier" attrs="{ 'invisible': [('supplier', '=', False)]}" />
+				</field>
+			</field>
+		</record> 
+
 	</data>
 </openerp>

--- a/l10n_br_account_product/sped/nfe/document.py
+++ b/l10n_br_account_product/sped/nfe/document.py
@@ -90,10 +90,11 @@ class NFe200(FiscalDocument):
                     self._encashment_data(cr, uid, ids, inv, line, context)
                     self.nfe.infNFe.cobr.dup.append(self.dup)
 
+            self._transport_data(cr, uid, ids, inv, context)
             try:
                 self._carrier_data(cr, uid, ids, inv, context)
             except AttributeError:
-                self._transport_data(cr, uid, ids, inv, context)
+                pass
 
             self.vol = self._get_Vol()
             self._weight_data(cr, uid, ids, inv, context=None)
@@ -411,29 +412,9 @@ class NFe200(FiscalDocument):
     def _carrier_data(self, cr, uid, ids, inv, context=None):
 
         #
-        # Dados da Transportadora e veiculo relacionados ao módulo delivery
+        # Dados de veiculo relacionados ao módulo delivery
         #
-
-        self.nfe.infNFe.transp.modFrete.valor = inv.incoterm and inv.incoterm.freight_responsibility or '9'
-
-        if inv.carrier_id:
-
-            if inv.carrier_id.partner_id.is_company:
-                self.nfe.infNFe.transp.transporta.CNPJ.valor = \
-                    re.sub('[%s]' % re.escape(string.punctuation), '', inv.carrier_id.partner_id.cnpj_cpf or '')
-            else:
-                self.nfe.infNFe.transp.transporta.CPF.valor = \
-                    re.sub('[%s]' % re.escape(string.punctuation), '', inv.carrier_id.partner_id.cnpj_cpf or '')
-
-            self.nfe.infNFe.transp.transporta.xNome.valor = inv.carrier_id.partner_id.legal_name[:60] or ''
-            self.nfe.infNFe.transp.transporta.IE.valor = inv.carrier_id.partner_id.inscr_est or ''
-            self.nfe.infNFe.transp.transporta.xEnder.valor = inv.carrier_id.partner_id.street or ''
-            self.nfe.infNFe.transp.transporta.xMun.valor = inv.carrier_id.partner_id.l10n_br_city_id.name or ''
-            self.nfe.infNFe.transp.transporta.UF.valor = inv.carrier_id.partner_id.state_id.code or ''
-
         if inv.vehicle_id:
-            self.nfe.infNFe.transp.veicTransp.placa.valor = inv.vehicle_id.plate or ''
-            self.nfe.infNFe.transp.veicTransp.UF.valor = inv.vehicle_id.state_id.code or ''
             self.nfe.infNFe.transp.veicTransp.RNTC.valor = inv.vehicle_id.rntc_code or ''
 
     def _transport_data(self, cr, uid, ids, inv, context=None):

--- a/l10n_br_delivery/account_invoice.py
+++ b/l10n_br_delivery/account_invoice.py
@@ -63,7 +63,7 @@ class AccountInvoice(models.Model):
                     strErro = u'Transportadora - Razão Social\n'
 
                 if not inv.carrier_id.partner_id.cnpj_cpf:
-                    strErro = 'Transportadora - CNPJ/CPF\n'
+                    strErro = u'Transportadora - CNPJ/CPF\n'
 
             # Carrier Vehicle
             if inv.vehicle_id:

--- a/l10n_br_delivery/account_invoice.py
+++ b/l10n_br_delivery/account_invoice.py
@@ -17,26 +17,39 @@
 #along with this program.  If not, see <http://www.gnu.org/licenses/>.        #
 ###############################################################################
 
-from openerp.osv import orm, fields
+from openerp import api, fields, models
 from openerp.tools.translate import _
 
 
-class AccountInvoice(orm.Model):
+class AccountInvoice(models.Model):
     _inherit = 'account.invoice'
-    _columns = {
-        'carrier_id': fields.many2one(
-            'delivery.carrier', 'Transportadora', readonly=True,
-            states={'draft': [('readonly', False)]}),
-        'vehicle_id': fields.many2one(
+    
+    carrier_id = fields.Many2one(
+            'delivery.carrier', 'Método de transporte', readonly=True,
+            states={'draft': [('readonly', False)]})
+    vehicle_id = fields.Many2one(
             'l10n_br_delivery.carrier.vehicle', u'Veículo', readonly=True,
-            states={'draft': [('readonly', False)]}),
-        'incoterm': fields.many2one(
+            states={'draft': [('readonly', False)]})
+    incoterm = fields.Many2one(
             'stock.incoterms', 'Tipo do Frete', readonly=True,
             states={'draft': [('readonly', False)]},
             help="Incoterm which stands for 'International Commercial terms' "
             "implies its a series of sales terms which are used in the "
-            "commercial transaction."),
-    }
+            "commercial transaction.")    
+    
+    @api.onchange('carrier_id')
+    def onchange_carrier_id(self):
+        self.partner_carrier_id = self.carrier_id.partner_id
+        
+    @api.onchange('vehicle_id')
+    def onchange_vehicle_id(self):
+        self.vehicle_plate = self.vehicle_id.plate
+        self.vehicle_state_id = self.vehicle_id.state_id
+        self.vehicle_l10n_br_city_id = self.vehicle_id.l10n_br_city_id
+        
+    @api.onchange('incoterm')
+    def onchange_incoterm(self):
+        self.freight_responsibility = self.incoterm.freight_responsibility
 
     def nfe_check(self, cr, uid, ids, context=None):
         result = super(AccountInvoice, self).nfe_check(cr, uid, ids, context)

--- a/l10n_br_delivery/account_invoice_view.xml
+++ b/l10n_br_delivery/account_invoice_view.xml
@@ -7,12 +7,16 @@
 			<field name="model">account.invoice</field>
 			<field name="inherit_id" ref="l10n_br_account_product.l10n_br_account_product_invoice_form"/>
 			<field name="arch" type="xml">
-				<field name="amount_freight" position="before">
-					<separator colspan="4" string="Dados da Transportadora"/>
-					<field name="carrier_id"/>
-					<field name="vehicle_id"/>
-					<field name="incoterm" widget="selection" />
-				</field>
+				<group name="delivery_info" position="after">
+					<group>						
+						<field name="carrier_id"/>
+						<field name="vehicle_id"/>
+						<field name="incoterm" widget="selection" />
+					</group>
+				</group>
+				<group name="delivery_info" position="attributes">
+					<attribute name="invisible">1</attribute>
+				</group>
 			</field>
 		</record>
 
@@ -21,12 +25,16 @@
 			<field name="model">account.invoice</field>
 			<field name="inherit_id" ref="l10n_br_account_product.l10n_br_account_product_invoice_supplier_form"/>
 			<field name="arch" type="xml">
-				<field name="amount_freight" position="before">
-					<separator colspan="4" string="Dados da Transportadora"/>
-					<field colspan="4" name="carrier_id"/>
-					<field name="vehicle_id"/>
-					<field name="incoterm" widget="selection" />
-				</field>
+				<group name="delivery_info" position="after">
+					<group>						
+						<field name="carrier_id"/>
+						<field name="vehicle_id"/>
+						<field name="incoterm" widget="selection" />
+					</group>
+				</group>
+				<group name="delivery_info" position="attributes">
+					<attribute name="invisible">1</attribute>
+				</group>
 			</field>
 		</record>
 

--- a/l10n_br_delivery/account_invoice_view.xml
+++ b/l10n_br_delivery/account_invoice_view.xml
@@ -7,16 +7,11 @@
 			<field name="model">account.invoice</field>
 			<field name="inherit_id" ref="l10n_br_account_product.l10n_br_account_product_invoice_form"/>
 			<field name="arch" type="xml">
-				<group name="delivery_info" position="after">
-					<group>						
-						<field name="carrier_id"/>
-						<field name="vehicle_id"/>
-						<field name="incoterm" widget="selection" />
-					</group>
-				</group>
-				<group name="delivery_info" position="attributes">
-					<attribute name="invisible">1</attribute>
-				</group>
+				<field name="freight_responsibility" position="before">											
+					<field name="carrier_id"/>
+					<field name="vehicle_id"/>
+					<field name="incoterm" widget="selection" />					
+				</field>				
 			</field>
 		</record>
 
@@ -25,16 +20,11 @@
 			<field name="model">account.invoice</field>
 			<field name="inherit_id" ref="l10n_br_account_product.l10n_br_account_product_invoice_supplier_form"/>
 			<field name="arch" type="xml">
-				<group name="delivery_info" position="after">
-					<group>						
-						<field name="carrier_id"/>
-						<field name="vehicle_id"/>
-						<field name="incoterm" widget="selection" />
-					</group>
-				</group>
-				<group name="delivery_info" position="attributes">
-					<attribute name="invisible">1</attribute>
-				</group>
+				<field name="freight_responsibility" position="before">											
+					<field name="carrier_id"/>
+					<field name="vehicle_id"/>
+					<field name="incoterm" widget="selection" />					
+				</field>	
 			</field>
 		</record>
 

--- a/l10n_br_delivery/account_invoice_view.xml
+++ b/l10n_br_delivery/account_invoice_view.xml
@@ -9,9 +9,9 @@
 			<field name="arch" type="xml">
 				<field name="freight_responsibility" position="before">											
 					<field name="carrier_id"/>
-					<field name="vehicle_id"/>
+					<field name="vehicle_id" domain="[('carrier_id', '=', carrier_id)]"/>
 					<field name="incoterm" widget="selection" />					
-				</field>				
+				</field>							
 			</field>
 		</record>
 
@@ -22,7 +22,7 @@
 			<field name="arch" type="xml">
 				<field name="freight_responsibility" position="before">											
 					<field name="carrier_id"/>
-					<field name="vehicle_id"/>
+					<field name="vehicle_id" domain="[('carrier_id', '=', carrier_id)]"/>
 					<field name="incoterm" widget="selection" />					
 				</field>	
 			</field>


### PR DESCRIPTION
@mileo @renatonlima 
Com este PR foram adicionados novos campos na fatura relacionados ao transporte, eliminando a necessidade de instalar o módulo delivery para escolher uma transportadora.

Quando instalado o módulo delivery os campos são ocultos, e o funcionamento é o mesmo que o anterior as modificações, porém sem o módulo instalado as informações da tag transporta na NF-e são geradas apartir dos campos de transporte do módulo l10n_br_account_product.

Visão com o módulo de delivery instalado e o xml gerado apartir do mesmo.
![with_delivery](https://cloud.githubusercontent.com/assets/854781/9289633/00462db4-434e-11e5-9657-3fd6f17ff472.png)
![xml_with_delivery](https://cloud.githubusercontent.com/assets/854781/9289635/008871b0-434e-11e5-80b1-94141b44c7c2.png)


Sem o módulo de delivery também é possível salvar as informações de transporte, porém sem a necessidade de se configurar os métodos de transporte.
![without_delivery](https://cloud.githubusercontent.com/assets/854781/9289634/007f6f34-434e-11e5-8fea-5d1f3986b0c1.png)
![xml_without_elivery](https://cloud.githubusercontent.com/assets/854781/9289636/008cef10-434e-11e5-9134-5cde6ee4cc17.png)

Criado opção para marcar o fornecedor como transportadora.
![captura de tela de 2015-08-15 13-06-20](https://cloud.githubusercontent.com/assets/854781/9289657/72f5d134-434e-11e5-963b-650cdbe2a6c1.png)
