### PR TITLE
[FIX] odoo-brazil#7 Correção de onchange do cnpj cpf, correção de con…

### DIFF
--- a/l10n_br_account/l10n_br_account.py
+++ b/l10n_br_account/l10n_br_account.py
@@ -381,7 +381,8 @@ class L10n_brAccountPartnerFiscalType(models.Model):
     @api.constrains('default')
     def _check_default(self):
         if self.default:
-            if len(self.search([('default', '=', 'True')])) > 1:
+            if self.search_count([('default', '=', 'True'),
+                                  ('is_company', '=', self.is_company)]) > 1:
                 raise Warning(_(u'Mantenha apenas um tipo fiscal padrão!'))
         return True
 

--- a/l10n_br_account/res_partner.py
+++ b/l10n_br_account/res_partner.py
@@ -367,20 +367,17 @@ class ResPartner(models.Model):
         o tipo fiscal para não contribuinte já que quando é criado um novo
         parceiro o valor do campo is_company é false"""
         return self.env['l10n_br_account.partner.fiscal.type'].search(
-            [('default', '=', 'True')], limit=1)
+            [('default', '=', 'True'), ('is_company', '=', self.is_company)],
+            limit=1)
 
     partner_fiscal_type_id = fields.Many2one(
         'l10n_br_account.partner.fiscal.type', string='Tipo Fiscal do Parceiro',
         domain="[('is_company', '=', is_company)]",
         default=_default_partner_fiscal_type_id)
 
-    def onchange_mask_cnpj_cpf(self, cr, uid, ids, is_company,
-                            cnpj_cpf, context=None):
-        result = super(ResPartner, self).onchange_mask_cnpj_cpf(
-            cr, uid, ids, is_company, cnpj_cpf, context)
-        ft_id = self._default_partner_fiscal_type_id(
-            cr, uid, is_company, context)
-
-        if ft_id:
-            result['value']['partner_fiscal_type_id'] = ft_id
-        return result
+    @api.onchange('is_company')
+    def _onchange_is_company(self):           
+        ft_id = self._default_partner_fiscal_type_id()
+        if ft_id:            
+            self.partner_fiscal_type_id = ft_id            
+        

--- a/l10n_br_base/res_partner.py
+++ b/l10n_br_base/res_partner.py
@@ -140,7 +140,7 @@ class ResPartner(models.Model):
         return True
 
     @api.onchange('cnpj_cpf')
-    def onchange_mask_cnpj_cpf(self):
+    def _onchange_cnpj_cpf(self):        
         if self.cnpj_cpf:
             val = re.sub('[^0-9]', '', self.cnpj_cpf)
             if len(val) == 14:


### PR DESCRIPTION
…straint no tipo fiscal do parceiro

Fix #7 

- Corrige constraint tipo fiscal do parceiro para permitir escolher um tipo padrão por pessoa física e um juridica.
- Corrige onchange do cnpf cpf.
- Modifica onchange que muda o tipo fiscal para usar o campo 'is_company'.