### PR TITLE
Padronização dos campos de endereço nas views de Prospectos, Oportunidades, ResCompany e ResPartner

### DIFF
--- a/l10n_br_base/res_company_view.xml
+++ b/l10n_br_base/res_company_view.xml
@@ -12,11 +12,11 @@
 				<field name="street2" position="replace"/>
 				<field name="zip" position="replace"/>
 				<field name="street" position="replace">
-					<field name="zip" placeholder="Cep" style="width:50%;" />
+					<field name="zip" placeholder="CEP" style="width:50%;" />
 					<field name="street"/>
-					<field name="number" placeholder="número"/>
-					<field name="street2" placeholder="complemento"/>
-					<field name="district" placeholder="bairro"/>
+					<field name="number" placeholder="Número"/>
+					<field name="street2" placeholder="Complemento"/>
+					<field name="district" placeholder="Bairro"/>
 				</field>				
 				<field name="state_id" position="attributes">
 					<attribute name="domain">[('country_id','=',country_id)]</attribute>
@@ -27,10 +27,10 @@
 				</field>
 				 <field name="country_id" position="replace"/>
         		<field name="state_id" position="before">
-                    <field name="country_id" placeholder="Pais"/>
+                    <field name="country_id" placeholder="País"/>
         		</field>
 				<field name="state_id" position="after">
-					<field name="l10n_br_city_id" placeholder="cidade"/>
+					<field name="l10n_br_city_id" placeholder="Cidade"/>
 				</field>
 				<field name="city" position="replace">
 					<field name="city" invisible="1"/>

--- a/l10n_br_base/res_partner_view.xml
+++ b/l10n_br_base/res_partner_view.xml
@@ -50,10 +50,10 @@
 				</field>
                 		<field name="zip" position="replace"/>
 				<field name="street" position="replace">
-					<field name="zip" placeholder="Cep"/>
-					<field name="street" placeholder="Logadouro"/>
-					<field name="number" placeholder="numero" />
-					<field name="district" placeholder="bairro" />
+					<field name="zip" placeholder="CEP"/>
+					<field name="street" placeholder="Logradouro"/>
+					<field name="number" placeholder="Número" />
+					<field name="district" placeholder="Bairro" />
 				</field>
 				<field name="street2" position="replace">
 					<field name="street2" placeholder="Complemento" />
@@ -63,14 +63,14 @@
 					<attribute name="style">width: 70%%</attribute>
 				</field>
 				<field name="state_id" position="after">
-					<field name="l10n_br_city_id" placeholder="cidade"/>
+					<field name="l10n_br_city_id" placeholder="Cidade"/>
 				</field>
 				<field name="city" position="replace">
 					<field name="city" invisible="1"/>
 				</field>
 		                <field name="country_id" position="replace"/>
                 		<field name="state_id" position="before">
-		                    <field name="country_id" placeholder="Pais"/>
+		                    <field name="country_id" placeholder="País"/>
                 		</field>
 		                <field name="zip" position="attributes">
                 		    <attribute name="style">width: 50%</attribute>

--- a/l10n_br_crm/crm_lead_view.xml
+++ b/l10n_br_crm/crm_lead_view.xml
@@ -1,41 +1,62 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
-	<data>
+    <data>
 
-		<!-- CRM Lead Form View  -->
-		<record model="ir.ui.view" id="l10n_br_crm_case_form_view_leads1">
-			<field name="name">l10n_br_crm.leads1</field>
-			<field name="model">crm.lead</field>
-			<field name="inherit_id" ref="crm.crm_case_form_view_leads" />
-			<field name="arch" type="xml">
-				<field name="city" position="replace">
-					<field name="city" invisible="1" />
-				</field>
-				<field name="state_id" position="replace">
-					<field name="state_id" placeholder="estado"/>
-					<field name="l10n_br_city_id" placeholder="municipio"/>
-				</field>
-				<field name="street2" position="replace">
-					<field name="district" placeholder="bairro"/>
-					<field name="number" placeholder="numero"/>
-					<field name="street2" placeholder="complemento"/>
-				</field>
-				<field name="partner_name" position="after">
-					<field name="legal_name" />
-					<field name="cnpj"/>
-					<field name="inscr_est"/>
-				</field>
+        <!-- CRM Lead Form View  -->
+        <record model="ir.ui.view" id="l10n_br_crm_case_form_view_leads1">
+            <field name="name">l10n_br_crm.leads1</field>
+            <field name="model">crm.lead</field>
+            <field name="inherit_id" ref="crm.crm_case_form_view_leads"/>
+            <field name="arch" type="xml">
+                <field name="city" position="replace">
+                    <field name="city" invisible="1"/>
+                </field>
+
+                <field name="zip" position="replace"/>
+                <field name="street" position="replace">
+                    <field name="zip" placeholder="CEP"/>
+                    <field name="street" placeholder="Logradouro"/>
+                    <field name="number" placeholder="Número"/>
+                    <field name="district" placeholder="Bairro"/>
+                </field>
+                <field name="street2" position="replace">
+                    <field name="street2" placeholder="Complemento"/>
+                </field>
+                <field name="state_id" position="attributes">
+                    <attribute name="domain">[('country_id','=',country_id)]
+                    </attribute>
+                    <attribute name="style">width: 70%%</attribute>
+                </field>
+                <field name="state_id" position="after">
+                    <field name="l10n_br_city_id" placeholder="Cidade"/>
+                </field>
+                <field name="city" position="replace">
+                    <field name="city" invisible="1"/>
+                </field>
+                <field name="country_id" position="replace"/>
+                <field name="state_id" position="before">
+                    <field name="country_id" placeholder="País"/>
+                </field>
+                <field name="zip" position="attributes">
+                    <attribute name="style">width: 50%</attribute>
+                </field>
+
+                <field name="partner_name" position="after">
+                    <field name="legal_name"/>
+                    <field name="cnpj"/>
+                    <field name="inscr_est"/>
+                </field>
                 <field name="email_from" position="before">
-                    <field name="name_surname" />
+                    <field name="name_surname"/>
                     <field name="cpf"/>
                     <field name="rg"/>
                 </field>
-				<field name="type" position="after">
-					<field name="inscr_mun" />
-					<field name="suframa" />
-				</field>
-			</field>
-		</record>
-	
-	</data>
+                <field name="type" position="after">
+                    <field name="inscr_mun"/>
+                    <field name="suframa"/>
+                </field>
+            </field>
+        </record>
+
+    </data>
 </openerp>

--- a/l10n_br_crm/crm_opportunity_view.xml
+++ b/l10n_br_crm/crm_opportunity_view.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
-	<data>
+    <data>
 
-		<!-- CRM Opportunity Form View  -->
-		<record model="ir.ui.view" id="l10n_br_crm_case_form_view_oppor1">
-			<field name="name">l10n_br_crm.opportunities1</field>
-			<field name="model">crm.lead</field>
-			<field name="inherit_id" ref="crm.crm_case_form_view_oppor" />
-			<field name="arch" type="xml">
-				<field name="city" position="replace">
-					<field name="city" invisible="1" />
-				</field>
+        <!-- CRM Opportunity Form View  -->
+        <record model="ir.ui.view" id="l10n_br_crm_case_form_view_oppor1">
+            <field name="name">l10n_br_crm.opportunities1</field>
+            <field name="model">crm.lead</field>
+            <field name="inherit_id" ref="crm.crm_case_form_view_oppor"/>
+            <field name="arch" type="xml">
+                <field name="city" position="replace">
+                    <field name="city" invisible="1"/>
+                </field>
 
-				<field name="zip" position="replace"/>
+                <field name="zip" position="replace"/>
                 <field name="street" position="replace">
                     <field name="zip" placeholder="CEP"/>
                     <field name="street" placeholder="Logradouro"/>
@@ -41,20 +41,20 @@
                     <attribute name="style">width: 50%</attribute>
                 </field>
 
-				<field name="partner_name" position="after">
-					<field name="legal_name" />
-					<field name="cnpj"/>
-					<field name="inscr_est" />
-					<field name="inscr_mun" />
-					<field name="suframa" />
-				</field>
+                <field name="partner_name" position="after">
+                    <field name="legal_name"/>
+                    <field name="cnpj"/>
+                    <field name="inscr_est"/>
+                    <field name="inscr_mun"/>
+                    <field name="suframa"/>
+                </field>
                 <field name="email_from" position="before">
-                    <field name="name_surname" />
+                    <field name="name_surname"/>
                     <field name="cpf"/>
                     <field name="rg"/>
                 </field>
-			</field>
-		</record>
+            </field>
+        </record>
 
-	</data>
+    </data>
 </openerp>

--- a/l10n_br_crm/crm_opportunity_view.xml
+++ b/l10n_br_crm/crm_opportunity_view.xml
@@ -11,15 +11,36 @@
 				<field name="city" position="replace">
 					<field name="city" invisible="1" />
 				</field>
-				<field name="state_id" position="replace">
-					<field name="state_id" placeholder="estado"/>
-					<field name="l10n_br_city_id" placeholder="municipio" />
-				</field>
-				<field name="street2" position="replace">
-					<field name="district" placeholder="bairro"/>
-					<field name="number" placeholder="numero" />
-					<field name="street2" placeholder="complemento" />
-				</field>
+
+				<field name="zip" position="replace"/>
+                <field name="street" position="replace">
+                    <field name="zip" placeholder="CEP"/>
+                    <field name="street" placeholder="Logradouro"/>
+                    <field name="number" placeholder="Número"/>
+                    <field name="district" placeholder="Bairro"/>
+                </field>
+                <field name="street2" position="replace">
+                    <field name="street2" placeholder="Complemento"/>
+                </field>
+                <field name="state_id" position="attributes">
+                    <attribute name="domain">[('country_id','=',country_id)]
+                    </attribute>
+                    <attribute name="style">width: 70%%</attribute>
+                </field>
+                <field name="state_id" position="after">
+                    <field name="l10n_br_city_id" placeholder="Cidade"/>
+                </field>
+                <field name="city" position="replace">
+                    <field name="city" invisible="1"/>
+                </field>
+                <field name="country_id" position="replace"/>
+                <field name="state_id" position="before">
+                    <field name="country_id" placeholder="País"/>
+                </field>
+                <field name="zip" position="attributes">
+                    <attribute name="style">width: 50%</attribute>
+                </field>
+
 				<field name="partner_name" position="after">
 					<field name="legal_name" />
 					<field name="cnpj"/>

--- a/l10n_br_crm_zip/views/crm_opportunity_view.xml
+++ b/l10n_br_crm_zip/views/crm_opportunity_view.xml
@@ -6,6 +6,7 @@
 	   	<record model="ir.ui.view" id="l10n_br_crm_case_form_view_oppor1">
 			<field name="name">l10n_br_crm.opportunities1</field>
 			<field name="model">crm.lead</field>
+			<field name="priority">33</field>
 			<field name="inherit_id" ref="crm.crm_case_form_view_oppor" />
 			<field name="arch" type="xml">
 				<field name="zip" position="after">

--- a/l10n_br_zip/models/l10n_br_zip.py
+++ b/l10n_br_zip/models/l10n_br_zip.py
@@ -35,7 +35,7 @@ class L10n_brZip(models.Model):
     street_type = fields.Char('Tipo', size=26)
     street = fields.Char('Logradouro', size=72)
     district = fields.Char('Bairro', size=72)
-    country_id = fields.Many2one('res.country', 'Country')
+    country_id = fields.Many2one('res.country', u'País')
     state_id = fields.Many2one(
         'res.country.state', 'Estado',
         domain="[('country_id','=',country_id)]")
@@ -54,7 +54,7 @@ class L10n_brZip(models.Model):
             if not state_id or not l10n_br_city_id or \
                     len(street or '') == 0:
                 raise except_orm(
-                    u'Parametros insuficientes',
+                    u'Parâmetros insuficientes',
                     u'Necessário informar Estado, município e logradouro')
 
             if country_id:


### PR DESCRIPTION
* Adicionado *domain* nos campos de seleção de País, Estado e Cidade das *views* de Oportunidade e de Prospectos.
* Ajustes na posição dos campos de endereço da view de Prospectos
![prospectos](https://cloud.githubusercontent.com/assets/8174740/10777266/a13c4820-7d00-11e5-9868-0e421f5f8791.png)

e de Oportunidade.
![oportunidades](https://cloud.githubusercontent.com/assets/8174740/10777272/b12969ac-7d00-11e5-87c1-7b71f08b2a14.png)

* Ajustes no texto dos *placeholders* dos campos de endereço de ResPartner e ResCompany de modo a deixá-los padronizados.

![respartner](https://cloud.githubusercontent.com/assets/8174740/10777275/b58e1c72-7d00-11e5-9bc9-ae01e76a849b.png)

* *Placeholder* dos campos *zip* em caixa alta, uma vez que a palavra "CEP" é um sigla.
* Tradução da string do campo *country_id* da tela de cadastro de CEP's (módulo *l10n_br_zip*) para português.