### PR TITLE
[FIX] Coluna Data da fatura na tree view vazia

### DIFF
--- a/l10n_br_account_product/account_invoice.py
+++ b/l10n_br_account_product/account_invoice.py
@@ -340,8 +340,13 @@ class AccountInvoice(models.Model):
         'fiscal_type': PRODUCT_FISCAL_TYPE_DEFAULT,
     }
 
-    def nfe_check(self, cr, uid, ids, context=None):
+    @api.onchange('date_hour_invoice')
+    def onchange_date_hour_invoice(self):
+        self.date_invoice = datetime.datetime.strptime(
+            self.date_hour_invoice, '%Y-%m-%d %H:%M:%S').date() \
+            if self.date_hour_invoice else ''
 
+    def nfe_check(self, cr, uid, ids, context=None):
         result = txt.validate(cr, uid, ids, context)
         return result
 


### PR DESCRIPTION
Coluna **"Data da Fatura"** na *tree view* não armazena (permanece vazia) o valor do campo **"Data Emissão"** exibido na *form view*, quando a fatura esta como **provisória**. 

Fix https://github.com/odoo-brazil/l10n-brazil/issues/133