### PR TITLE
[FIX] Frete, seguro e outros custos do Pedido de Venda não são transferidos para fatura

### DIFF
--- a/l10n_br_account_product/account_invoice.py
+++ b/l10n_br_account_product/account_invoice.py
@@ -891,7 +891,7 @@ class AccountInvoiceTax(models.Model):
                 other_costs_value=line.other_costs_value)['taxes']:
                 val = {}
                 val['invoice_id'] = inv.id
-                val['name'] = tax['name']
+                val['name'] = tax['name'] or ''
                 val['amount'] = tax['amount']
                 val['manual'] = False
                 val['sequence'] = tax['sequence']

--- a/l10n_br_delivery/stock.py
+++ b/l10n_br_delivery/stock.py
@@ -48,6 +48,28 @@ class StockPicking(orm.Model):
             result['freight_value'] = move_line.sale_line_id.freight_value
         return result
 
+    def _get_invoice_vals(self, cr, uid, key, inv_type, journal_id, move,
+                          context=None):
+
+        inv_vals = super(StockPicking, self)._get_invoice_vals(
+            cr, uid, key, inv_type, journal_id, move, context=context)
+
+        picking = move.picking_id
+
+        values = {
+            'partner_shipping_id': picking.partner_id.id,
+            'carrier_id': picking.carrier_id and picking.carrier_id.id,
+            'vehicle_id': picking.vehicle_id and picking.vehicle_id.id,
+            'weight': picking.weight,
+            'weight_net': picking.weight_net,
+            'number_of_packages': picking.number_of_packages,
+            'incoterm': picking.sale_id.incoterm.id
+            if picking.sale_id and picking.sale_id.incoterm.id else False,
+        }
+
+        inv_vals.update(values)
+        return inv_vals
+
 
 class StockMove(orm.Model):
     _inherit = 'stock.move'

--- a/l10n_br_delivery/stock.py
+++ b/l10n_br_delivery/stock.py
@@ -47,3 +47,22 @@ class StockPicking(orm.Model):
             result['other_costs_value'] = move_line.sale_line_id.other_costs_value
             result['freight_value'] = move_line.sale_line_id.freight_value
         return result
+
+
+class StockMove(orm.Model):
+    _inherit = 'stock.move'
+
+    def _get_invoice_line_vals(self, cr, uid, move, partner, inv_type,
+                               context=None):
+        res = super(StockMove, self)._get_invoice_line_vals(
+            cr, uid, move, partner, inv_type, context=context)
+        if move.procurement_id and move.procurement_id.sale_line_id:
+            sale_line = move.procurement_id.sale_line_id
+
+            res.update({
+                'insurance_value': sale_line.insurance_value,
+                'freight_value': sale_line.freight_value,
+                'other_costs_value': sale_line.other_costs_value,
+            })
+
+        return res

--- a/l10n_br_delivery/stock.py
+++ b/l10n_br_delivery/stock.py
@@ -47,23 +47,3 @@ class StockPicking(orm.Model):
             result['other_costs_value'] = move_line.sale_line_id.other_costs_value
             result['freight_value'] = move_line.sale_line_id.freight_value
         return result
-
-    def _invoice_hook(self, cr, uid, picking, invoice_id):
-        """Call after the creation of the invoice."""
-        context = {}
-
-        self.pool.get('account.invoice').write(
-            cr, uid, invoice_id, {
-                'partner_shipping_id': picking.partner_id.id,
-                'carrier_id': picking.carrier_id and picking.carrier_id.id,
-                'vehicle_id': picking.vehicle_id and picking.vehicle_id.id,
-                'incoterm': picking.incoterm.id,
-                'weight': picking.weight,
-                'weight_net': picking.weight_net,
-                'number_of_packages': picking.number_of_packages})
-
-        return super(StockPicking, self)._invoice_hook(
-            cr, uid, picking, invoice_id)
-
-
-


### PR DESCRIPTION
Frete, seguro e outros custos do Pedido de Venda não são transferidos para fatura quando a mesma é gerada a partir de uma Ordem de Entrega. Fixed #132 

A transportadora e o tipo de frete também não estavam sendo transferidos. 

A correção substitui os métodos *_prepare_invoice_line* (que foi substituido pelos metodos a seguir) e *_invoice_hook*(não é usado em lugar algum) por *_get_invoice_line_vals* e *_get_ivoice_vals*.