### PR TITLE
Mudança relacionada a NT 2015/003 referente ao IE do destinatário.

### DIFF
--- a/l10n_br_account_product/sped/nfe/document.py
+++ b/l10n_br_account_product/sped/nfe/document.py
@@ -263,9 +263,14 @@ class NFe200(FiscalDocument):
         if inv.partner_id.is_company:
             self.nfe.infNFe.dest.CNPJ.valor = re.sub('[%s]' % re.escape(string.punctuation), '', inv.partner_id.cnpj_cpf or '')
             self.nfe.infNFe.dest.IE.valor = re.sub('[%s]' % re.escape(string.punctuation), '', inv.partner_id.inscr_est or '')
+            if inv.partner_id.inscr_est:
+                self.nfe.infNFe.dest.indIEDest.valor = '1'
+            else:
+                self.nfe.infNFe.dest.indIEDest.valor = '2'
         else:
             self.nfe.infNFe.dest.CPF.valor = re.sub('[%s]' % re.escape(string.punctuation), '', inv.partner_id.cnpj_cpf or '')
-
+            self.nfe.infNFe.dest.indIEDest.valor = '9'
+            
         self.nfe.infNFe.dest.enderDest.xLgr.valor = inv.partner_id.street or ''
         self.nfe.infNFe.dest.enderDest.nro.valor = inv.partner_id.number or ''
         self.nfe.infNFe.dest.enderDest.xCpl.valor = inv.partner_id.street2 or ''


### PR DESCRIPTION
Essas mudanças devem ser integradas junto ao PR do Danimar referente a mudanças no PySPED.

Essas mudanças tratam a tag indIEDest da Nfe, seguindo a lógica.

se o parceiro for uma empresa (is_company=True) e possuir IE a tag indIEDest assumirá o valor 1, caso não possua IE assumirá valor 2 e se o parceiro não for uma empresa assumirá o valor 9.