### PR TITLE
[FIX] Ajusta para o uso do decorator api.one pelo core

### DIFF
--- a/l10n_br_base/models/copied_account_payment_term.py
+++ b/l10n_br_base/models/copied_account_payment_term.py
@@ -9,7 +9,7 @@ from __future__ import division, print_function, unicode_literals
 
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError
-import dateutil.relativedelta as relativedelta
+from dateutil.relativedelta import relativedelta
 
 
 class AccountPaymentTerm(models.Model):
@@ -70,6 +70,14 @@ class AccountPaymentTerm(models.Model):
             raise ValidationError(_(u"""A Payment Term should have only one
             line of type Balance."""))
 
+    #
+    # PELAMORDEDEUS!!!!
+    # Esse api.one era pra ser deprecado, só que não, o core continua usando
+    # Tentei trocar pro self.ensure_one, mas o decorator injeta o retorno
+    # do método dentro de uma lista, com um único elemento.
+    # Pois é...
+    #
+    @api.one
     def compute(self, value, date_ref=False):
         self.ensure_one()
         date_ref = date_ref or fields.Date.today()

--- a/l10n_br_base/models/inherited_account_payment_term.py
+++ b/l10n_br_base/models/inherited_account_payment_term.py
@@ -446,4 +446,8 @@ class AccountPaymentTerm(models.Model):
 
             res.append(parcela)
 
-        return res
+        #
+        # Emula o retorno conforme o decorator api.one, colocando o retorno
+        # numa lista com um único elemento
+        #
+        return [res]

--- a/sped/models/sped_documento.py
+++ b/sped/models/sped_documento.py
@@ -1134,8 +1134,13 @@ class SpedDocumento(models.Model):
         if not valor:
             valor = D(self.vr_nf or 0)
 
+        #
+        # Para a compatibilidade com a chamada original (super), que usa
+        # o decorator deprecado api.one, pegamos aqui sempre o 1º elemento
+        # da lista que vai ser retornada
+        #
         lista_vencimentos = self.payment_term_id.compute(valor,
-                                                         self.data_emissao)
+                                                         self.data_emissao)[0]
 
         duplicata_ids = [
             [5, False, {}],


### PR DESCRIPTION
Descrição do problema/nova funcionalidade deste Pull Resquest(PR):
------------------------------------------------------------------
O account.payment.term usa um decorator deprecado desde a versão 9 no método compute.
Infelizmente, usar o self.ensure_one() no lugar do @api.one evita o problema de passar um
recordset para o método, mas o api.one injeta o retorno do método em uma lista com um único 
elemento, e tivemos que ajustar de acordo.

- [ ] Esta mudança não altera a estrutura do banco de dados, portanto não precisa de script de migração.

--
Eu confirmo que eu assinei a CLA e li as recomendações de como contribuir:
- https://odoo-community.org/page/cla
- https://odoo-community.org/page/Contribute