### PR TITLE
[FIX] The method to get the next useful day need to add one day before validation.

### DIFF
--- a/l10n_br_resource/models/resource_calendar.py
+++ b/l10n_br_resource/models/resource_calendar.py
@@ -198,9 +198,9 @@ class ResourceCalendar(models.Model):
         :return datetime Proximo dia util apartir da data referencia
         """
         while data_referencia:
+            data_referencia += timedelta(days=1)
             if self.data_eh_dia_util(data_referencia):
                 return data_referencia
-            data_referencia += timedelta(days=1)
 
     @api.multi
     def proximo_dia_util_bancario(self, data_referencia=datetime.now()):


### PR DESCRIPTION
Descrição do problema/nova funcionalidade deste Pull Resquest(PR):
------------------------------------------------------------------

- O método que verifica o próximo dia útil estava verificando inicialmente a data recebida o que causava erro porque se data fosse um dia útil retornava ela mesma ao invés do próximo dia útil.


- [x] Esta mudança não altera a estrutura do banco de dados, portanto não precisa de script de migração.

--
Eu confirmo que eu assinei a CLA e li as recomendações de como contribuir:
- https://odoo-community.org/page/cla
- https://odoo-community.org/page/Contribute